### PR TITLE
Add benchmarks for stack and insert modes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +175,18 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "approx"
@@ -347,6 +368,7 @@ dependencies = [
  "bevy_log",
  "bevy_reflect",
  "bevy_time",
+ "criterion",
  "immediate_stats",
 ]
 
@@ -1790,6 +1812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1857,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +1893,31 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -2072,6 +2152,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2197,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3730,6 +3864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "orbclient"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +3894,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3858,6 +4008,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -4068,6 +4246,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "read-fonts"
@@ -4663,6 +4861,16 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bevy_log = { version = "0.18", default-features = false }
 [dev-dependencies]
 bevy = "0.18"
 bevy_auto_plugin = { version = "0.9" }
+criterion = { version = "0.8" }
 immediate_stats = { version = "0.4", features = ["bevy_auto_plugin"] }
 
 [lints.rust]
@@ -52,3 +53,18 @@ path = "examples/immediate_stats/decaying_speed.rs"
 [[example]]
 name = "decaying_speed_auto_plugin"
 path = "examples/immediate_stats/decaying_speed_auto_plugin.rs"
+
+[[bench]]
+name = "baseline"
+path = "benches/baseline.rs"
+harness = false
+
+[[bench]]
+name = "stack_mode"
+path = "benches/stack_mode.rs"
+harness = false
+
+[[bench]]
+name = "insert_mode"
+path = "benches/insert_mode.rs"
+harness = false

--- a/benches/baseline.rs
+++ b/benches/baseline.rs
@@ -1,0 +1,82 @@
+//! Benchmarks for standard Bevy equivalents of effect operations.
+
+use bevy_alchemy::{AlchemyPlugin, EffectMode, EffectedBy, Effecting};
+use bevy_app::App;
+use bevy_ecs::name::Name;
+use bevy_ecs::prelude::{Component, Entity, Spawn};
+use bevy_ecs::spawn::SpawnRelated;
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[derive(Component)]
+struct BenchEffect;
+
+fn init_app() -> (App, Entity, Entity) {
+    let mut app = App::new();
+    app.add_plugins(AlchemyPlugin);
+
+    let target = app.world_mut().spawn(Name::new("Target")).id();
+    let effect = app
+        .world_mut()
+        .spawn((
+            Effecting(target),
+            Name::new("Effect"),
+            EffectMode::Stack,
+            BenchEffect,
+        ))
+        .id();
+
+    (app, target, effect)
+}
+
+/// Spawning new effect, similar to `EffectMode::Stack`.
+fn with_related(c: &mut Criterion) {
+    let (mut app, target, _) = init_app();
+
+    c.bench_function("Baseline `with_related`", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(target)
+                .with_related::<Effecting>((Name::new("Effect"), EffectMode::Stack, BenchEffect));
+            app.world_mut().flush();
+        })
+    });
+}
+
+/// Spawning new effect, similar to `EffectMode::Stack`.
+fn related_spawner(c: &mut Criterion) {
+    let (mut app, target, _) = init_app();
+
+    c.bench_function("Baseline related spawner", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(target)
+                .insert(EffectedBy::spawn(Spawn((
+                    Name::new("Effect"),
+                    EffectMode::Stack,
+                    BenchEffect,
+                ))));
+            app.world_mut().flush();
+        })
+    });
+}
+
+/// Inserting into an existing effect, similar to `EffectMode::Insert`.
+fn insert(c: &mut Criterion) {
+    let (mut app, _, effect) = init_app();
+
+    c.bench_function("Baseline insert", |b| {
+        b.iter(|| {
+            app.world_mut().commands().entity(effect).insert((
+                Name::new("Effect"),
+                EffectMode::Stack,
+                BenchEffect,
+            ));
+            app.world_mut().flush();
+        })
+    });
+}
+
+criterion_group!(benches, with_related, related_spawner, insert);
+criterion_main!(benches);

--- a/benches/insert_mode.rs
+++ b/benches/insert_mode.rs
@@ -1,0 +1,68 @@
+//! Benchmarks for applying insert-mode effects.
+
+use bevy_alchemy::{AlchemyPlugin, EffectBundle, EffectCommandsExt, EffectMode, EffectedBy};
+use bevy_app::App;
+use bevy_ecs::name::Name;
+use bevy_ecs::prelude::{Component, Entity, SpawnRelated};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[derive(Component)]
+struct BenchEffect;
+
+fn init_app() -> (App, Entity) {
+    let mut app = App::new();
+    app.add_plugins(AlchemyPlugin);
+
+    let entity = app
+        .world_mut()
+        .spawn((
+            Name::new("Target"),
+            EffectedBy::spawn(EffectBundle {
+                name: Name::new("Effect"),
+                mode: EffectMode::Insert,
+                bundle: BenchEffect,
+            }),
+        ))
+        .id();
+
+    (app, entity)
+}
+
+fn with_effect(c: &mut Criterion) {
+    let (mut app, entity) = init_app();
+
+    c.bench_function("Insert mode matched `with_effect`", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(entity)
+                .with_effect(EffectBundle {
+                    name: Name::new("Effect"),
+                    mode: EffectMode::Insert,
+                    bundle: BenchEffect,
+                });
+            app.world_mut().flush();
+        })
+    });
+}
+
+fn related_spawner(c: &mut Criterion) {
+    let (mut app, entity) = init_app();
+
+    c.bench_function("Insert mode matched related spawner", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(entity)
+                .insert(EffectedBy::spawn(EffectBundle {
+                    name: Name::new("Effect"),
+                    mode: EffectMode::Insert,
+                    bundle: BenchEffect,
+                }));
+            app.world_mut().flush();
+        })
+    });
+}
+
+criterion_group!(benches, with_effect, related_spawner);
+criterion_main!(benches);

--- a/benches/stack_mode.rs
+++ b/benches/stack_mode.rs
@@ -1,0 +1,58 @@
+//! Benchmarks for applying stack-mode effects.
+
+use bevy_alchemy::{AlchemyPlugin, EffectBundle, EffectCommandsExt, EffectMode, EffectedBy};
+use bevy_app::App;
+use bevy_ecs::name::Name;
+use bevy_ecs::prelude::{Component, Entity, SpawnRelated};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[derive(Component)]
+struct BenchEffect;
+
+fn init_app() -> (App, Entity) {
+    let mut app = App::new();
+    app.add_plugins(AlchemyPlugin);
+
+    let entity = app.world_mut().spawn(Name::new("Target")).id();
+
+    (app, entity)
+}
+
+fn with_effect(c: &mut Criterion) {
+    let (mut app, entity) = init_app();
+
+    c.bench_function("Stack mode `with_effect`", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(entity)
+                .with_effect(EffectBundle {
+                    name: Name::new("Effect"),
+                    mode: EffectMode::Stack,
+                    bundle: BenchEffect,
+                });
+            app.world_mut().flush();
+        })
+    });
+}
+
+fn related_spawner(c: &mut Criterion) {
+    let (mut app, entity) = init_app();
+
+    c.bench_function("Stack mode related spawner", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(entity)
+                .insert(EffectedBy::spawn(EffectBundle {
+                    name: Name::new("Effect"),
+                    mode: EffectMode::Stack,
+                    bundle: BenchEffect,
+                }));
+            app.world_mut().flush();
+        })
+    });
+}
+
+criterion_group!(benches, with_effect, related_spawner);
+criterion_main!(benches);


### PR DESCRIPTION
Includes benchmarks for `with_effect` and `EffectedBy::spawn` in both stack and insert modes. Also includes some benchmarks for Bevy's existing `with_related` and  related spawning, which act as a baseline to compare against.