### PR TITLE
Merge system overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "bevy_log",
  "bevy_reflect",
  "bevy_time",
+ "bevy_utils",
  "criterion",
  "immediate_stats",
 ]
@@ -1580,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e258c44d869f9c41ac0f88a16815c67f2569eb9fff4716828a40273d127b6f84"
+checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
 dependencies = [
  "bevy_platform",
  "disqualified",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
 ]
@@ -136,23 +136,22 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cc",
- "cesu8",
- "jni",
- "jni-sys",
+ "jni 0.22.4",
  "libc",
  "log",
  "ndk 0.9.0",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -184,9 +183,15 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -232,7 +237,7 @@ checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -261,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -285,10 +290,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "3.4.1"
+name = "async-io"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -337,18 +360,18 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec689b5a79452b6f777b889bbff22d3216b82a8d2ab7814d4a0eb571e9938d97"
+checksum = "1fd310426290cec560221f9750c2f4484be4a8eeea7de3483c423329b465c40e"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69b6d2dec07cbf407c63f6987e1746e4b735a9beea51f4bfc25ad49e344f75"
+checksum = "e887b25c84f384ffe3278a17cf0e4b405eaa3c8fbc3db24d05d560a11780676d"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -359,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_alchemy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bevy",
  "bevy_app",
@@ -375,18 +398,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_android"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008133458cfe0d43a8870bfc4c5a729467cc5d9246611462add38bcf45ed896f"
+checksum = "a8c58de772ac1148884112e8a456c4f127a94b95a0e42ab5b160b7a11895a241"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c852457843456c695ed22562969c83c3823454c3c40d359f92415371208ee7"
+checksum = "be5bf5b285f0d3fab983b4505e62e195e06930a29007ffc95bdabde834e163a2"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -409,7 +432,7 @@ dependencies = [
  "ron",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "thread_local",
  "tracing",
  "uuid",
@@ -417,20 +440,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac120bfd5a74e05f96013817d28318dc716afaa68864af069c7ffc3ccaf9d153"
+checksum = "7cf35516d0e7ac9ec25df533be1bf8cbaa20596a8e65f36838a3f7803a267d6d"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_anti_alias"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418087f7c36a62c9886b55be6278e7b3d21c9943b107953aa2068000956a736"
+checksum = "726cc494eb7d6a84ce6291c23636fd451fa4846604dc059fa93febca4e60a928"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -450,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2271a0123a7cc355c3fe98754360c75aa84b29f2a6b1a9f8c00aac427570d174"
+checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -465,7 +488,7 @@ dependencies = [
  "ctrlc",
  "downcast-rs 2.0.2",
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "variadics_please",
  "wasm-bindgen",
  "web-sys",
@@ -473,13 +496,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f7361669d1426a3359cb92f890ef9c62bd6e6b67f0190d2c5279d25ce24168"
+checksum = "29f86fed15972b9fb1a3f7b092cf0390e67131caaedab15a2707c043e3a3c886"
 dependencies = [
  "async-broadcast",
  "async-channel",
  "async-fs",
+ "async-io",
  "async-lock",
  "atomicow",
  "bevy_android",
@@ -491,7 +515,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -505,7 +529,7 @@ dependencies = [
  "ron",
  "serde",
  "stackfuture",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "wasm-bindgen",
@@ -515,21 +539,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288e1edf17069afe2e02a0c0e7e5936b3d22a67c7d2dc9201a27e4451875f909"
+checksum = "12cb8d948365b06561b43b7d709282e62a6abb756baac5d8e295206d5e156168"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_audio"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cbecfc6c5d3860f224f56d3152b14aa313168d35c16e847f5a0202a992c3af"
+checksum = "9d68da32468ce7f4bb2863b71326acfaaa88e9aef8da8306257cd487d40cede4"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -580,15 +604,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smart-default",
- "syn 2.0.111",
- "thiserror 2.0.17",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "bevy_camera"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c7e1f2a5da1755cd58e45c762f4ea2d72cef6c480f9c8ddbadbd2a4380c616"
+checksum = "37ed9eed054e14341852236d06a7244597b1ace39ff9ae023fbd188ffde88619"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -606,15 +630,15 @@ dependencies = [
  "downcast-rs 2.0.2",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_color"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74727302424d7ffc23528a974dbb44a34708662926e1a3bfc5040493f858886e"
+checksum = "2eb41e8310a85811d14a4e75cfc2d6c07ac70661d6a4883509fc960f622970a8"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -622,15 +646,15 @@ dependencies = [
  "derive_more",
  "encase",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e6bf0ba878bb5dd00ad4d70875b08eb11367829668c70d95785f5483ddb1cb"
+checksum = "4d0810e85c2436e50c67448d48a83bf0bb1b5849899619ae2c7ea817221e9172"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -648,30 +672,30 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "nonmax",
  "radsort",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b6a05c31f54c83d681f1b8699bbaf581f06b25a40c9a6bb815625f731f5ba9"
+checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_dev_tools"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3183daa165acce210c50c170c47433c90b1d55932ead9734ebca14b7cd242c4"
+checksum = "a4f1464a3f5ef5c23d917987714ee89881f9f791e9ff97ecf6600ee846b9569e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -698,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca4caa8a9014a435dca382b1bdebaee4363e9be69882c598fc4ff4d7cd56e6a"
+checksum = "ec8543a0f7afd56d3499ba80ffab6ef0bad12f93c2d2ca9aa7b1f1b8816c3980"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -716,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24637a7c8643cab493f4085cda6bde4895f0e0816699c59006f18819da2ca0b8"
+checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -727,7 +751,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bumpalo",
  "concurrent-queue",
  "derive_more",
@@ -738,37 +762,67 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb14c18ca71e11c69fbae873c2db129064efac6d52e48d0127d37bfba1acfa8"
+checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f89146a8fcbfe47310fc929ee762dd3b08d4de3e3371c601529cfa8eeb861de"
+checksum = "d4fee46eeddcbc00a805ae00ffa973f224671fc5cf0fe1a796963804faeade90"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
 ]
 
 [[package]]
-name = "bevy_gilrs"
-version = "0.18.0"
+name = "bevy_feathers"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c76417261ff3cd7ecda532b58514224aee06e76fbd87636c3a80695be7c8192"
+checksum = "1cb29be8f8443c5cc44e1c4710bbe02877e73703c60228ca043f20529a5496c6"
+dependencies = [
+ "accesskit",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_color",
+ "bevy_derive",
+ "bevy_ecs",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_picking",
+ "bevy_platform",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_text",
+ "bevy_ui",
+ "bevy_ui_render",
+ "bevy_ui_widgets",
+ "bevy_window",
+ "smol_str",
+]
+
+[[package]]
+name = "bevy_gilrs"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611827ab0ce43b88c0a695e6603901b5f34687efecaf526c861456c9d8e6fedb"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -776,15 +830,15 @@ dependencies = [
  "bevy_platform",
  "bevy_time",
  "gilrs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc78a5699580c2dce078f4c099028d26525a5a38e8eb587a31854c660a3c5ff7"
+checksum = "6aaff0dd5f405c83d290c5cd591835f1ae8009894947ab19dadcb323062bd7e7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -802,20 +856,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bb92e0ef80ff7c59429133244765515db3d313fae77ee67ffe94dab5b2725d"
+checksum = "6960ea308d7e94adcac5c712553ff86614bba6b663511f3f3812f6bec028b51e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_gizmos_render"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fde3172a31f81033b4f497dd9df84476f527fadb00936ede380fb646c402eb"
+checksum = "4a8d18c089102de4c5e9326023ad96ba618a6961029f8102a33640b966883237"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -838,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08372f222676dba313061fc71128209b82f9711e7c5cba222b5c34bf1c5c70fe"
+checksum = "5f37fb52655d0439656ca0a1db027d46926e463c81d893d4b1639668e5d7f1c1"
 dependencies = [
  "async-lock",
  "base64",
@@ -868,15 +922,15 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_image"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809101ebe678a76c4c5ba3ecad255cde9be3ae0af591cf0143ba2c157afb55e9"
+checksum = "a71daf9b2afdd032c2b1122d1d501f99126218cb3e9983b3604ec381daa35f22"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -886,7 +940,7 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "futures-lite",
  "guillotiere",
@@ -896,16 +950,16 @@ dependencies = [
  "rectangle-pack",
  "ruzstd",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_input"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2853993baf27b963a417d3603a73e02e39c5041913cd1ba7211b0a3037b191"
+checksum = "dbc8ffbd02df34dfc52faf420a5263985973765e228043adf542fd0d790a6b21"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -915,14 +969,14 @@ dependencies = [
  "derive_more",
  "log",
  "smol_str",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fc0fae5e4e081180f7f7bf8023a2b97dad13dcb5fa79eba50cda5bb95699a9"
+checksum = "08d48a5bceccb9157549a39ab3de4017f5368b65db6471605e9a3f1c19d91bbc"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -932,14 +986,14 @@ dependencies = [
  "bevy_reflect",
  "bevy_window",
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "bevy_internal"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57463815630ea71221c0b8e7bff72d816a3071a89507c45f9e2686fbb5e1956b"
+checksum = "6a11df62e49897def470471551c02f13c6fb488e55dddb5ab7ef098132e07754"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -955,6 +1009,7 @@ dependencies = [
  "bevy_dev_tools",
  "bevy_diagnostic",
  "bevy_ecs",
+ "bevy_feathers",
  "bevy_gilrs",
  "bevy_gizmos",
  "bevy_gizmos_render",
@@ -991,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_light"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9968b8f8a6a766a88b66144474c39d1415edc277d042fec1526eae85e1f8b4"
+checksum = "4d9d2ac64390a9baacb3c0fa0f5456ac1553959d5a387874c102a09aab8b92cc"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1012,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406304a9b867a2de98c3edf0cc9e5a608fad1a1ddc567e15e72c186a8273ef51"
+checksum = "c2aac1187f83a1ab2eae887564f7fb14b4abb3fbe8b2267a6426663463923120"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1030,21 +1085,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7272fca0bf30d8ca2571a803598856104b63e5c596d52850f811ed37c5e1e3"
+checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
- "toml_edit",
+ "syn 2.0.117",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a815c514b8a6f7b11508cdc8b3a4bf0761e96a14227af40aa93cb1160989ce0"
+checksum = "e931fa969f89c83498b22c97432383afe90e90fd1a5e04fa07be8da4d3bcac84"
 dependencies = [
  "approx",
  "arrayvec",
@@ -1056,15 +1111,15 @@ dependencies = [
  "rand",
  "rand_distr",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_mesh"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacf09d0ffd1a15baf8d201c4a34b918912a506395c2817aa55ab3d3776c09f2"
+checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1076,11 +1131,11 @@ dependencies = [
  "bevy_platform",
  "bevy_reflect",
  "bevy_transform",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "hexasphere",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wgpu-types",
 ]
@@ -1093,9 +1148,9 @@ checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
 
 [[package]]
 name = "bevy_pbr"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cc361c65035f7e531b592d99bce95b6ab3f643cae2abe97dfa7681363159a6"
+checksum = "a5ab6944ffc6fd71604c0fbca68cc3e2a3654edfcdbfd232f9d8b88e3d20fdc0"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1116,7 +1171,7 @@ dependencies = [
  "bevy_shader",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -1124,15 +1179,15 @@ dependencies = [
  "offset-allocator",
  "smallvec",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_picking"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d10bb2a776087e1d8a9b87e8deb091d25bcedbe6160c613df2dc5fe069c3c5"
+checksum = "b7d524dbc8f2c9e73f7ab70c148c8f7886f3c24b8aa8c252a38ba68ed06cbf10"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1154,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b29ea749a8e85f98186ab662f607b885b97c804bb14cdb0cdf838164496d474"
+checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -1174,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_post_process"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e1116cbc35637f267a29c7d2fe376e020f2b4402d6b525d328bae9c10460c7"
+checksum = "8f77a4e894aea992e3d6938f1d5898a1cdbb87dba6eebfb95cb4038d0a2600e9"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1194,25 +1249,25 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "nonmax",
  "radsort",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f98cbc6d34bbdb58240b72ed1731931b4991a893b3a3238bb7c42ae054aa676"
+checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2a977e2b8dba65b6e9c11039c5f9ef108be428f036b3d1cac13ad86ec59f9c"
+checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1231,7 +1286,7 @@ dependencies = [
  "serde",
  "smallvec",
  "smol_str",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid",
  "variadics_please",
  "wgpu-types",
@@ -1239,23 +1294,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067af30072b1611fda1a577f1cb678b8ea2c9226133068be808dd49aac30cef0"
+checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_render"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b2c9a276646bde8ba58a7e15711b459fb4a5cdf46c47059b7a310f97a70d9c"
+checksum = "243523e33fe5dfcebc4240b1eb2fc16e855c5d4c0ea6a8393910740956770f44"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1278,7 +1333,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "downcast-rs 2.0.2",
@@ -1293,7 +1348,7 @@ dependencies = [
  "offset-allocator",
  "send_wrapper",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "variadics_please",
  "wasm-bindgen",
@@ -1303,21 +1358,21 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e16b8cac95b87021399ed19f6ab79c0b1e03101a448e3a0240934f78f66a56"
+checksum = "66b6325e9c495a71270446784611e8d7f446f927eac8506c4c099fd10cb4c3ed"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_scene"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046bb071ee358619f2fa9409ccced47375502b098b4107ec3385f3a1acf6600"
+checksum = "34cc1047d85ec8048261b63ef675c12f1e6b5782dc0b422fbcee0c140d026bd4"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1331,15 +1386,15 @@ dependencies = [
  "derive_more",
  "ron",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_shader"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a14cb0991b2482a66b94728cbcf7482d1b74364be017197396435d3d542b8d3"
+checksum = "9eea95f0273c32be13d6a0b799a93bc256ad7830759ede595c404d5234302da2"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
@@ -1347,16 +1402,16 @@ dependencies = [
  "naga",
  "naga_oil",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_sprite"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3921ce1a8ce801c29d9552cbc204548bfeb16b9b829045c9e82b5917d99cc"
+checksum = "96ec5bc0cbdee551b610a46f41d30374bbe42b8951ffc676253c6243ab2b9395"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1379,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite_render"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed40642fa0e1330df65b6a1bf0b14aa32fcd9d7f3306e08e0784c10362bd6265"
+checksum = "b82cb08905e7ddcea2694a95f757ae7f1fd01e6a7304076bad595d2158e4bfe0"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1401,7 +1456,7 @@ dependencies = [
  "bevy_text",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "derive_more",
  "fixedbitset",
@@ -1411,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9453325ca0c185a043f4515158daa15a8ab19139a60fd1edaf87fbe896cb7f83"
+checksum = "0ae0682968e97d29c1eccc8c6bb6283f2678d362779bc03f1bb990967059473b"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1427,20 +1482,20 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d733081e57e49b3c43bdf3766d1de74c7df32e0f4db20c20437c85b1d18908de"
+checksum = "73d32f90f9cfcef5a44401db7ce206770daaa1707b0fb95eb7a96a6933f54f1b"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bevy_tasks"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990ffedd374dd2c4fe8f0fd4bcefd5617d1ee59164b6c3fcc356a69b48e26e8e"
+checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1457,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbb6eeaa9a63d1f8aae8c0d79f8d5e14c584a962a4ef9f69115fd7d10941101"
+checksum = "fdc5233291dfc22e584de2535f2e37ae9766d37cb5a01652de2133ba202dcb9b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1476,16 +1531,16 @@ dependencies = [
  "serde",
  "smallvec",
  "sys-locale",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "wgpu-types",
 ]
 
 [[package]]
 name = "bevy_time"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c68b78e7ca1cc10c811cd1ded8350f53f2be11eb46946879a74c684026bff7"
+checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1498,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30e3957de42c2f7d88dfe8428e739b74deab8932d2a8bbb9d4eefbd64b6aa34"
+checksum = "3c3bb3de7842fef699344beb03f22bdbff16599d788fe0f47fbb3b1e6fa320eb"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1511,14 +1566,14 @@ dependencies = [
  "bevy_utils",
  "derive_more",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "bevy_ui"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889c6892e9c5c308ab225a1322d07fb2358ccf39493526cda4d5f083d717773d"
+checksum = "1691a411014085e0d35f8bb8208e5f973edd7ace061a4b1c41c83de21579dc70"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1543,16 +1598,16 @@ dependencies = [
  "derive_more",
  "smallvec",
  "taffy",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "bevy_ui_render"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b649395e32a4761d4f17aeff37170a4421c94a14c505645397b8ee8510eb19e9"
+checksum = "c2c35402d8a052f512e3fec1f36b26e83eee713fcca57f965c244ee795e1fcb0"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1580,6 +1635,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_ui_widgets"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a63cb818b0de41bdb14990e0ce1aaaa347f871750ab280f80c427e83d72712"
+dependencies = [
+ "accesskit",
+ "bevy_a11y",
+ "bevy_app",
+ "bevy_camera",
+ "bevy_ecs",
+ "bevy_input",
+ "bevy_input_focus",
+ "bevy_log",
+ "bevy_math",
+ "bevy_picking",
+ "bevy_reflect",
+ "bevy_ui",
+]
+
+[[package]]
 name = "bevy_utils"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869a56f1da2544641734018e1f1caa660299cd6e3af794f3fa0df72293d8eed2"
+checksum = "6df06e6993a0896bae2fe7644ae6def29a1a92b45dfb1bcebbd92af782be3638"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1611,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a3749fc491eeae481c30bb3830cf5a71d2fa3dba4d450a42792f6d39eb2d"
+checksum = "f2de1c13d32ab8528435b58eca7ab874a1068184c6d6f266ee11433ae99d4069"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -1649,16 +1724,16 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1684,9 +1759,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "bytemuck",
  "serde_core",
@@ -1694,15 +1769,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1726,7 +1802,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1744,15 +1820,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1765,7 +1841,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1782,9 +1858,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calloop"
@@ -1792,7 +1868,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -1820,9 +1896,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1984,9 +2060,9 @@ checksum = "87ca1caa64ef4ed453e68bb3db612e51cf1b2f5b871337f0fcab1c8f87cc3dff"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "constgebra"
@@ -2062,7 +2138,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -2102,7 +2178,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cadaea21e24c49c0c82116f2b465ae6a49d63c90e428b0f8d9ae1f638ac91f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "fontdb",
  "harfrust",
  "linebender_resource_handle",
@@ -2130,7 +2206,7 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -2141,6 +2217,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.54.0",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2244,12 +2329,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix",
+ "nix 0.31.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2280,7 +2365,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2291,7 +2376,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2302,30 +2387,30 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "derive_more"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -2337,14 +2422,14 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2355,9 +2440,9 @@ checksum = "c9c272297e804878a2a4b707cfcfc6d2328b5bb936944613b4fdf2b9269afdfd"
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -2403,7 +2488,7 @@ checksum = "6e3e0ff2ee0b7aa97428308dd9e1e42369cb22f5fb8dc1c55546637443a60f1e"
 dependencies = [
  "const_panic",
  "encase_derive",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2423,7 +2508,7 @@ checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2434,9 +2519,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -2455,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.11"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -2500,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -2512,9 +2597,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2543,6 +2628,15 @@ name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
 dependencies = [
  "bytemuck",
 ]
@@ -2588,7 +2682,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2599,24 +2693,24 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -2633,32 +2727,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -2667,7 +2761,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -2679,15 +2773,28 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "gilrs"
-version = "0.11.0"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb2c998745a3c1ac90f64f4f7b3a54219fd3612d7705e7798212935641ed18f"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "gilrs"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa85c2e35dc565c90511917897ea4eae16b77f2773d5223536f7b602536d462"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -2698,18 +2805,18 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be11a71ac3564f6965839e2ed275bf4fcf5ce16d80d396e1dfdb7b2d80bd587e"
+checksum = "d23f2cc5144060a7f8d9e02d3fce5d06705376568256a509cdbc3c24d47e4f04"
 dependencies = [
- "core-foundation 0.10.1",
  "inotify",
- "io-kit-sys",
  "js-sys",
  "libc",
  "libudev-sys",
  "log",
- "nix",
+ "nix 0.30.1",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "uuid",
  "vec_map",
  "wasm-bindgen",
@@ -2730,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.9"
+version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd47b05dddf0005d850e5644cae7f2b14ac3df487979dbfff3b56f20b1a6ae46"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 dependencies = [
  "bytemuck",
  "encase",
@@ -2780,7 +2887,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2810,7 +2917,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "gpu-alloc-types",
 ]
 
@@ -2820,7 +2927,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2841,7 +2948,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2852,7 +2959,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2889,7 +2996,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0caaee032384c10dd597af4579c67dee16650d862a9ccbe1233ff1a379abc07"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "core_maths",
  "read-fonts 0.36.0",
@@ -2938,6 +3045,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,9 +3087,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3001,14 +3120,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -3024,11 +3143,11 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -3044,21 +3163,11 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "io-kit-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
-dependencies = [
- "core-foundation-sys",
- "mach2",
 ]
 
 [[package]]
@@ -3081,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -3094,7 +3203,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3102,10 +3211,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.0"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -3113,16 +3274,18 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -3150,7 +3313,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7f53bdf698e7aa7ec916411bbdc8078135da11b66db5182675b2227f6c0d07"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3158,6 +3321,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lewton"
@@ -3172,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -3188,19 +3357,20 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.11"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.6.0",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3236,7 +3406,7 @@ checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3247,9 +3417,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
@@ -3301,15 +3471,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -3320,7 +3490,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -3347,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -3363,7 +3533,7 @@ checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -3378,7 +3548,7 @@ dependencies = [
  "pp-rs",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
@@ -3394,7 +3564,7 @@ dependencies = [
  "naga",
  "regex",
  "rustc-hash 1.1.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-ident",
 ]
@@ -3405,8 +3575,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.10.0",
- "jni-sys",
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
@@ -3419,8 +3589,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
- "jni-sys",
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -3440,7 +3610,7 @@ version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3449,7 +3619,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3458,7 +3628,19 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3482,9 +3664,9 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "ntapi"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
@@ -3506,7 +3688,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3521,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3531,14 +3713,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3568,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -3581,7 +3763,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -3597,7 +3779,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -3621,7 +3803,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -3633,7 +3815,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3672,7 +3854,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -3685,6 +3867,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
  "objc2-core-foundation",
 ]
@@ -3707,7 +3890,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -3719,7 +3902,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation",
@@ -3742,7 +3925,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -3774,7 +3957,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -3787,7 +3970,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "ndk 0.8.0",
  "ndk-context",
  "num-derive",
@@ -3825,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -3837,18 +4020,19 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "orbclient"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad146e19b9437f8604c21f8652423595cf710ad108af40e77d3ae6e96b827"
+checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
 dependencies = [
+ "libc",
  "libredox",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "5.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -3928,41 +4112,35 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -3974,6 +4152,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4005,11 +4189,11 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4026,21 +4210,21 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -4070,12 +4254,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "toml_edit",
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -4104,9 +4298,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -4119,27 +4313,24 @@ checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "pxfm"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
-dependencies = [
- "num-traits",
-]
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4149,6 +4340,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radsort"
@@ -4178,11 +4375,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4197,15 +4394,15 @@ dependencies = [
 
 [[package]]
 name = "range-alloc"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d6831663a5098ea164f89cff59c6284e95f4e3c76ce9848d4529f5ccca9bde"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rangemap"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbbbbea733ec66275512d0b9694f34102e7d5406fdbe2ad8d21b28dce92887c"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "raw-window-handle"
@@ -4235,23 +4432,23 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
-dependencies = [
- "bytemuck",
- "font-types",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eaa2941a4c05443ee3a7b26ab076a553c343ad5995230cc2b1d3e993bdc6345"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types",
+ "font-types 0.10.1",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types 0.11.2",
 ]
 
 [[package]]
@@ -4275,23 +4472,23 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96166dafa0886eb81fe1c0a388bece180fbef2135f97c1e2cf8302e74b43b5"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4301,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4312,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renderdoc-sys"
@@ -4334,11 +4531,11 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -4360,9 +4557,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4379,7 +4576,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4388,14 +4585,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4413,12 +4610,6 @@ checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
 dependencies = [
  "twox-hash",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -4456,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -4499,20 +4690,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -4532,19 +4723,25 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "skrifa"
-version = "0.37.0"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "bytemuck",
- "read-fonts 0.35.0",
+ "rustc_version",
+ "simdutf8",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "skrifa"
@@ -4557,10 +4754,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.11"
+name = "skrifa"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -4585,7 +4792,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4594,7 +4801,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -4637,7 +4844,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4681,11 +4888,11 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
+checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
- "skrifa 0.37.0",
+ "skrifa 0.40.0",
  "yazi",
  "zeno",
 ]
@@ -4702,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4766,11 +4973,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4781,18 +4988,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4841,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4864,24 +5071,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4903,7 +5131,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4941,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4991,9 +5219,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typewit"
-version = "1.14.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+checksum = "06fee3a8df48c50c55ad646a4e03b00a370da6fe1850ebf467a8d0165dfcafae"
 
 [[package]]
 name = "unicode-bidi"
@@ -5003,9 +5231,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5021,9 +5249,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5039,11 +5267,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5063,7 +5291,7 @@ checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5090,18 +5318,27 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5112,22 +5349,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5135,35 +5369,69 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.11"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs 1.2.1",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -5171,12 +5439,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.11"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.10.0",
- "rustix 1.1.2",
+ "bitflags 2.11.0",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5187,29 +5455,29 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.11"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.9"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5217,11 +5485,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5230,11 +5498,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5243,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.7"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -5254,9 +5522,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.7"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -5265,9 +5533,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5290,7 +5558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -5319,7 +5587,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -5334,7 +5602,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
@@ -5379,7 +5647,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block",
  "bytemuck",
  "cfg-if",
@@ -5410,7 +5678,7 @@ dependencies = [
  "raw-window-handle",
  "renderdoc-sys",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -5424,12 +5692,12 @@ version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -5606,7 +5874,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5617,7 +5885,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5628,7 +5896,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5639,7 +5907,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5915,14 +6183,14 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.12"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop",
@@ -5967,18 +6235,109 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "x11-dl"
@@ -6002,7 +6361,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -6024,7 +6383,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "dlib",
  "log",
  "once_cell",
@@ -6057,20 +6416,26 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,8 @@ harness = false
 name = "insert_mode"
 path = "benches/insert_mode.rs"
 harness = false
+
+[[bench]]
+name = "merge_mode"
+path = "benches/merge_mode.rs"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_alchemy"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "An experimental, status effects-as-entities system for Bevy."
 categories = ["game-development"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bevy_reflect = { version = "0.18", default-features = false }
 bevy_time = { version = "0.18", default-features = false, features = [
   "bevy_reflect",
 ] }
-bevy_utils = { version = "0.18.1", default-features = false }
+bevy_utils = { version = "0.18", default-features = false }
 
 [dev-dependencies]
 bevy = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ bevy_app = { version = "0.18", default-features = false, features = [
 bevy_ecs = { version = "0.18", default-features = false, features = [
   "bevy_reflect",
 ] }
+bevy_log = { version = "0.18", default-features = false }
 bevy_reflect = { version = "0.18", default-features = false }
 bevy_time = { version = "0.18", default-features = false, features = [
   "bevy_reflect",
 ] }
-bevy_log = { version = "0.18", default-features = false }
+bevy_utils = { version = "0.18.1", default-features = false }
 
 [dev-dependencies]
 bevy = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ immediate_stats = { version = "0.5.0", features = ["bevy_auto_plugin"] }
 [lints.rust]
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
-unsafe_code = "deny"
 unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 

--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ A handful of components are included that are intended to make it easier to crea
 
 | Bevy   | Bevy Alchemy  |
 |--------|---------------|
-| `0.18` | `0.2` - `0.4` |
+| `0.18` | `0.2` - `0.5` |
 | `0.17` | `0.1`         |

--- a/benches/merge_mode.rs
+++ b/benches/merge_mode.rs
@@ -1,0 +1,70 @@
+//! Benchmarks for applying merge-mode effects.
+
+use bevy_alchemy::{
+    AlchemyPlugin, Effect, EffectCommandsExt, EffectMode, EffectStacks, EffectedBy,
+};
+use bevy_app::App;
+use bevy_ecs::name::Name;
+use bevy_ecs::prelude::{Component, Entity, SpawnRelated};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+#[derive(Component, Clone)]
+struct BenchEffect;
+
+fn init_app() -> (App, Entity) {
+    let mut app = App::new();
+    app.add_plugins(AlchemyPlugin);
+
+    let entity = app
+        .world_mut()
+        .spawn((
+            Name::new("Target"),
+            EffectedBy::spawn(Effect((
+                Name::new("Effect"),
+                EffectMode::Merge,
+                BenchEffect,
+                EffectStacks::default(),
+            ))),
+        ))
+        .id();
+
+    (app, entity)
+}
+
+fn with_effect(c: &mut Criterion) {
+    let (mut app, entity) = init_app();
+
+    c.bench_function("Merge mode matched `with_effect`", |b| {
+        b.iter(|| {
+            app.world_mut().commands().entity(entity).with_effect((
+                Name::new("Effect"),
+                EffectMode::Merge,
+                BenchEffect,
+                EffectStacks::default(),
+            ));
+            app.world_mut().flush();
+        })
+    });
+}
+
+fn related_spawner(c: &mut Criterion) {
+    let (mut app, entity) = init_app();
+
+    c.bench_function("Merge mode matched related spawner", |b| {
+        b.iter(|| {
+            app.world_mut()
+                .commands()
+                .entity(entity)
+                .insert(EffectedBy::spawn(Effect((
+                    Name::new("Effect"),
+                    EffectMode::Merge,
+                    BenchEffect,
+                    EffectStacks::default(),
+                ))));
+            app.world_mut().flush();
+        })
+    });
+}
+
+criterion_group!(benches, with_effect, related_spawner);
+criterion_main!(benches);

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -1,6 +1,13 @@
 use crate::EffectMode;
-use bevy_ecs::prelude::{Bundle, Entity, Name, Resource, World};
+use bevy_ecs::component::ComponentId;
+use bevy_ecs::prelude::{Bundle, Entity, EntityRef, Name, Resource, World};
+use bevy_ecs::ptr::OwningPtr;
 use bevy_ecs::relationship::RelationshipHookMode;
+use std::alloc::alloc;
+use std::any::TypeId;
+use std::error::Error;
+use std::fmt::Formatter;
+use std::ptr::{NonNull, copy_nonoverlapping};
 
 #[derive(Resource)]
 pub(crate) struct BundleInspector {
@@ -35,11 +42,86 @@ impl BundleInspector {
             .copied()
             .unwrap_or_default();
 
-        self.world.entity_mut(e).clear();
-
         (name, mode)
     }
+
+    pub fn clear(&mut self) {
+        self.world.entity_mut(self.scratch_entity).clear();
+    }
+
+    pub fn get_ref(&'_ self) -> EntityRef<'_> {
+        self.world.entity(self.scratch_entity)
+    }
+
+    pub fn get_type_id(&self, component_id: ComponentId) -> Option<TypeId> {
+        self.world
+            .components()
+            .get_info(component_id)
+            .and_then(|info| info.type_id())
+    }
+
+    pub unsafe fn copy_to_world(
+        &self,
+        dst_world: &mut World,
+        dst_entity: Entity,
+        type_id: TypeId,
+        src_component_id: ComponentId,
+    ) -> Result<(), MultiWorldCopyError> {
+        let Some(existing_component_id) = dst_world.components().get_id(type_id) else {
+            return Err(MultiWorldCopyError::Unregistered(type_id));
+        };
+
+        let component_info = dst_world
+            .components()
+            .get_info(existing_component_id)
+            .unwrap();
+
+        if component_info.drop().is_some() {
+            return Err(MultiWorldCopyError::UnCopyable(type_id));
+        }
+
+        unsafe {
+            let src = self
+                .world
+                .get_by_id(self.scratch_entity, src_component_id)
+                .unwrap();
+            let dst = alloc(component_info.layout());
+
+            copy_nonoverlapping(src.as_ptr(), dst, component_info.layout().size());
+
+            let owning = OwningPtr::new(NonNull::new(dst).unwrap());
+
+            dst_world
+                .entity_mut(dst_entity)
+                .insert_by_id(existing_component_id, owning);
+        }
+
+        Ok(())
+    }
 }
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum MultiWorldCopyError {
+    Unregistered(TypeId),
+    UnCopyable(TypeId),
+}
+
+impl std::fmt::Display for MultiWorldCopyError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MultiWorldCopyError::Unregistered(type_id) => write!(
+                f,
+                "Component with type ID {type_id:?} has not been registered in the main world, and therefor cannot be inserted using merge mode."
+            ),
+            MultiWorldCopyError::UnCopyable(type_id) => write!(
+                f,
+                "Component with type ID {type_id:?} cannot be copied, and therefor cannot be inserted using merge mode."
+            ),
+        }
+    }
+}
+
+impl Error for MultiWorldCopyError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -87,9 +87,11 @@ impl BundleInspector {
     ///
     /// # Errors
     /// Will return an error if:
+    /// - The component is not registered in `dst_world`.
     /// - The component cannot be cloned ([`ComponentCloneBehavior::Ignore`]).
     /// - The stashed bundle doesn't contain the component.
     /// - The destination entity doesn't exist in `dst_world`.
+    /// - The resource AppTypeRegistry doesn't exist in `dst_world`.
     ///
     /// # Safety
     /// `src_component_id` must be for the same component as `type_id`.
@@ -100,8 +102,9 @@ impl BundleInspector {
         type_id: TypeId,
         src_component_id: ComponentId,
     ) -> Result<&Self, MultiWorldCopyError> {
-        //
-        let dst_component_id = dst_world.components().get_id(type_id).unwrap();
+        let Some(dst_component_id) = dst_world.components().get_id(type_id) else {
+            return Err(MultiWorldCopyError::Unregistered(type_id));
+        };
         let component_info = dst_world.components().get_info(dst_component_id).unwrap();
 
         match component_info.clone_behavior() {
@@ -124,21 +127,24 @@ impl BundleInspector {
                 let dst = alloc(component_info.layout());
 
                 // SAFETY: `dst` is allocated from the component's layout.
-                // Both IDs provided by the caller must match, and `src` and `dst` obtained using the IDs.
+                // Both IDs provided by the caller must match, and `src` and `dst` are obtained using those IDs.
                 // `src` and `dst` are from different worlds, so cannot overlap.
                 copy_nonoverlapping(src.as_ptr(), dst, component_info.layout().size());
 
+                // SAFETY: Both IDs provided by the caller must match, and `dst` was created from `src`.
                 let owning = OwningPtr::new(NonNull::new(dst).unwrap());
 
                 // SAFETY: `existing_component_id` is extracted from `dst_world`.
-                // Both IDs provided by the caller must match, `owning` was obtained using `src_component_id`.
+                // Both IDs provided by the caller must match, and `owning` was obtained using `src_component_id`.
                 dst_world
                     .get_entity_mut(dst_entity)
                     .map_err(|_| MultiWorldCopyError::MissingDstEntity(dst_entity))?
                     .insert_by_id(dst_component_id, owning);
             }
         } else {
-            let registry = dst_world.resource::<AppTypeRegistry>().clone();
+            let Some(registry) = dst_world.get_resource::<AppTypeRegistry>().cloned() else {
+                return Err(MultiWorldCopyError::MissingTypeRegistry);
+            };
             let registry = registry.read();
 
             let reflect_component = registry
@@ -160,14 +166,20 @@ impl BundleInspector {
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum MultiWorldCopyError {
+    Unregistered(TypeId),
     Uncloneable(DebugName),
     MissingDstEntity(Entity),
     MissingSrcComponent(DebugName, Entity),
+    MissingTypeRegistry,
 }
 
 impl std::fmt::Display for MultiWorldCopyError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            MultiWorldCopyError::Unregistered(type_id) => write!(
+                f,
+                "Component with {type_id:?} is not registered in the destination world, and therefor cannot be inserted using merge mode.",
+            ),
             MultiWorldCopyError::Uncloneable(name) => write!(
                 f,
                 "Component {name} cannot be cloned, and therefor cannot be inserted using merge mode.",
@@ -179,6 +191,10 @@ impl std::fmt::Display for MultiWorldCopyError {
             MultiWorldCopyError::MissingSrcComponent(name, entity) => write!(
                 f,
                 "Component {name} does not exist on the scratch entity {entity}, and therefor cannot be cloned.",
+            ),
+            MultiWorldCopyError::MissingTypeRegistry => write!(
+                f,
+                "Resource AppTypeRegistry does not exist in the destination world, and therefor no components can be cloned.",
             ),
         }
     }

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -27,26 +27,35 @@ impl Default for BundleInspector {
 }
 
 impl BundleInspector {
-    pub fn get_effect_meta<B: Bundle>(&mut self, bundle: B) -> (Option<Name>, EffectMode) {
-        let e = self.scratch_entity;
+    pub fn stash_bundle<B: Bundle>(&mut self, bundle: B) -> &mut Self {
         self.world
-            .entity_mut(e)
+            .entity_mut(self.scratch_entity)
             .insert_with_relationship_hook_mode(bundle, RelationshipHookMode::Skip);
 
-        let name = self.world.entity(e).get::<Name>().cloned();
+        self
+    }
+
+    pub fn clear(&mut self) -> &mut Self {
+        self.world.entity_mut(self.scratch_entity).clear();
+
+        self
+    }
+
+    pub fn get_effect_meta(&self) -> (Option<Name>, EffectMode) {
+        let name = self
+            .world
+            .entity(self.scratch_entity)
+            .get::<Name>()
+            .cloned();
 
         let mode = self
             .world
-            .entity_mut(e)
+            .entity(self.scratch_entity)
             .get::<EffectMode>()
             .copied()
             .unwrap_or_default();
 
         (name, mode)
-    }
-
-    pub fn clear(&mut self) {
-        self.world.entity_mut(self.scratch_entity).clear();
     }
 
     pub fn get_ref(&'_ self) -> EntityRef<'_> {
@@ -66,7 +75,7 @@ impl BundleInspector {
         dst_entity: Entity,
         type_id: TypeId,
         src_component_id: ComponentId,
-    ) -> Result<(), MultiWorldCopyError> {
+    ) -> Result<&Self, MultiWorldCopyError> {
         let Some(existing_component_id) = dst_world.components().get_id(type_id) else {
             return Err(MultiWorldCopyError::Unregistered(type_id));
         };
@@ -80,11 +89,12 @@ impl BundleInspector {
             return Err(MultiWorldCopyError::UnCopyable(type_id));
         }
 
+        let Some(src) = self.world.get_by_id(self.scratch_entity, src_component_id) else {
+            return Err(MultiWorldCopyError::MissingSrcComponent(type_id));
+        };
+
         unsafe {
-            let src = self
-                .world
-                .get_by_id(self.scratch_entity, src_component_id)
-                .unwrap();
+            // SAFETY: Contract is required to be upheld by the world.
             let dst = alloc(component_info.layout());
 
             copy_nonoverlapping(src.as_ptr(), dst, component_info.layout().size());
@@ -92,11 +102,12 @@ impl BundleInspector {
             let owning = OwningPtr::new(NonNull::new(dst).unwrap());
 
             dst_world
-                .entity_mut(dst_entity)
+                .get_entity_mut(dst_entity)
+                .map_err(|_| MultiWorldCopyError::MissingDstEntity(dst_entity))?
                 .insert_by_id(existing_component_id, owning);
         }
 
-        Ok(())
+        Ok(self)
     }
 }
 
@@ -104,6 +115,8 @@ impl BundleInspector {
 pub enum MultiWorldCopyError {
     Unregistered(TypeId),
     UnCopyable(TypeId),
+    MissingDstEntity(Entity),
+    MissingSrcComponent(TypeId),
 }
 
 impl std::fmt::Display for MultiWorldCopyError {
@@ -111,11 +124,19 @@ impl std::fmt::Display for MultiWorldCopyError {
         match self {
             MultiWorldCopyError::Unregistered(type_id) => write!(
                 f,
-                "Component with type ID {type_id:?} has not been registered in the main world, and therefor cannot be inserted using merge mode."
+                "Component with type ID {type_id:?} has not been registered in the inspector world, and therefor cannot be inserted using merge mode."
             ),
             MultiWorldCopyError::UnCopyable(type_id) => write!(
                 f,
                 "Component with type ID {type_id:?} cannot be copied, and therefor cannot be inserted using merge mode."
+            ),
+            MultiWorldCopyError::MissingDstEntity(entity) => write!(
+                f,
+                "Entity {entity} does not exist in the destination world."
+            ),
+            MultiWorldCopyError::MissingSrcComponent(type_id) => write!(
+                f,
+                "Component with type ID {type_id:?} does not exist in inspector world, and therefor cannot be inserted using merge mode."
             ),
         }
     }
@@ -136,7 +157,9 @@ mod tests {
         let mode = EffectMode::Insert;
 
         assert_eq!(
-            inspector.get_effect_meta((name.clone(), mode)),
+            inspector
+                .stash_bundle((name.clone(), mode))
+                .get_effect_meta(),
             (Some(name), mode)
         );
     }
@@ -147,7 +170,7 @@ mod tests {
 
         let mode = EffectMode::Insert;
 
-        assert_eq!(inspector.get_effect_meta(mode), (None, mode));
+        assert_eq!(inspector.stash_bundle(mode).get_effect_meta(), (None, mode));
     }
 
     #[test]
@@ -157,7 +180,7 @@ mod tests {
         let name = Name::new("Effect");
 
         assert_eq!(
-            inspector.get_effect_meta(name.clone()),
+            inspector.stash_bundle(name.clone()).get_effect_meta(),
             (Some(name), EffectMode::default())
         );
     }
@@ -166,7 +189,10 @@ mod tests {
     fn get_effect_meta_nothing() {
         let mut inspector = BundleInspector::default();
 
-        assert_eq!(inspector.get_effect_meta(()), (None, EffectMode::default()));
+        assert_eq!(
+            inspector.stash_bundle(()).get_effect_meta(),
+            (None, EffectMode::default())
+        );
     }
 
     #[test]
@@ -177,11 +203,13 @@ mod tests {
         let mode = EffectMode::Insert;
 
         assert_eq!(
-            inspector.get_effect_meta((
-                name.clone(),
-                mode,
-                Effecting(Entity::from_raw_u32(32).unwrap())
-            )),
+            inspector
+                .stash_bundle((
+                    name.clone(),
+                    mode,
+                    Effecting(Entity::from_raw_u32(32).unwrap())
+                ))
+                .get_effect_meta(),
             (Some(name), mode)
         );
     }

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -27,6 +27,9 @@ impl Default for BundleInspector {
 }
 
 impl BundleInspector {
+    /// Stashes a bundle so it can be inspected.
+    ///
+    /// Should be [cleared](Self::clear) when finished.
     pub fn stash_bundle<B: Bundle>(&mut self, bundle: B) -> &mut Self {
         self.world
             .entity_mut(self.scratch_entity)
@@ -35,12 +38,14 @@ impl BundleInspector {
         self
     }
 
+    /// Clears the [stashed bundle](Self::stash_bundle).
     pub fn clear(&mut self) -> &mut Self {
         self.world.entity_mut(self.scratch_entity).clear();
 
         self
     }
 
+    /// Returns the [stashed bundle's](Self::stash_bundle) name and effect mode.
     pub fn get_effect_meta(&self) -> (Option<Name>, EffectMode) {
         let name = self
             .world
@@ -58,10 +63,13 @@ impl BundleInspector {
         (name, mode)
     }
 
+    /// Returns a reference to the [stashed bundle](Self::stash_bundle).
     pub fn get_ref(&'_ self) -> EntityRef<'_> {
         self.world.entity(self.scratch_entity)
     }
 
+    /// Converts a component ID to a type ID, if registered.
+    /// The component ID must be from the inspector's world, using [`get_type_id`](Self::get_type_id).
     pub fn get_type_id(&self, component_id: ComponentId) -> Option<TypeId> {
         self.world
             .components()
@@ -69,6 +77,18 @@ impl BundleInspector {
             .and_then(|info| info.type_id())
     }
 
+    /// Copies a component from the [stashed bundle](Self::stash_bundle) into an entity in a different world.
+    /// The component ID must be from the inspector's world, using [`get_type_id`](Self::get_type_id).
+    ///
+    /// # Errors
+    /// Will return an error if:
+    /// - The component has not been registered in `dst_world`.
+    /// - The component cannot be copied (implements drop).
+    /// - The stashed bundle doesn't contain the component.
+    /// - The destination entity doesn't exist in `dst_world`.
+    ///
+    /// # Safety
+    /// `src_component_id` must be for the same component as `type_id`.
     pub unsafe fn copy_to_world(
         &self,
         dst_world: &mut World,
@@ -83,7 +103,7 @@ impl BundleInspector {
         let component_info = dst_world
             .components()
             .get_info(existing_component_id)
-            .unwrap();
+            .unwrap(); // Already checked that component is registered.
 
         if component_info.drop().is_some() {
             return Err(MultiWorldCopyError::UnCopyable(type_id));
@@ -97,10 +117,15 @@ impl BundleInspector {
             // SAFETY: Contract is required to be upheld by the world.
             let dst = alloc(component_info.layout());
 
+            // SAFETY: `dst` is allocated from the component's layout.
+            // Both IDs provided by the caller must match, and `src` and `dst` obtained using the IDs.
+            // `src` and `dst` are from different worlds, so cannot overlap.
             copy_nonoverlapping(src.as_ptr(), dst, component_info.layout().size());
 
             let owning = OwningPtr::new(NonNull::new(dst).unwrap());
 
+            // SAFETY: `existing_component_id` is extracted from `dst_world`.
+            // Both IDs provided by the caller must match, `owning` was obtained using `src_component_id`.
             dst_world
                 .get_entity_mut(dst_entity)
                 .map_err(|_| MultiWorldCopyError::MissingDstEntity(dst_entity))?

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -32,7 +32,7 @@ impl Default for BundleInspector {
 impl BundleInspector {
     /// Stashes a bundle so it can be inspected.
     ///
-    /// Should be [cleared](Self::clear) when finished.
+    /// Calls [`clear`](Self::clear) first to avoid leakage.
     pub fn stash_bundle<B: Bundle>(&mut self, bundle: B) -> &mut Self {
         self.clear();
 
@@ -87,8 +87,7 @@ impl BundleInspector {
     ///
     /// # Errors
     /// Will return an error if:
-    /// - The component has not been registered in `dst_world`.
-    /// - The component cannot be copied (implements drop).
+    /// - The component cannot be cloned ([`ComponentCloneBehavior::Ignore`]).
     /// - The stashed bundle doesn't contain the component.
     /// - The destination entity doesn't exist in `dst_world`.
     ///
@@ -101,11 +100,9 @@ impl BundleInspector {
         type_id: TypeId,
         src_component_id: ComponentId,
     ) -> Result<&Self, MultiWorldCopyError> {
-        let Some(dst_component_id) = dst_world.components().get_id(type_id) else {
-            return Err(MultiWorldCopyError::Unregistered(type_id));
-        };
-
-        let component_info = dst_world.components().get_info(dst_component_id).unwrap(); // Already checked that component is registered.
+        //
+        let dst_component_id = dst_world.components().get_id(type_id).unwrap();
+        let component_info = dst_world.components().get_info(dst_component_id).unwrap();
 
         match component_info.clone_behavior() {
             ComponentCloneBehavior::Default | ComponentCloneBehavior::Custom(_) => {}
@@ -163,7 +160,6 @@ impl BundleInspector {
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum MultiWorldCopyError {
-    Unregistered(TypeId),
     Uncloneable(DebugName),
     MissingDstEntity(Entity),
     MissingSrcComponent(DebugName, Entity),
@@ -172,10 +168,6 @@ pub enum MultiWorldCopyError {
 impl std::fmt::Display for MultiWorldCopyError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            MultiWorldCopyError::Unregistered(type_id) => write!(
-                f,
-                "Component with {type_id:?} has not been registered in the destination world, and therefor cannot be cloned."
-            ),
             MultiWorldCopyError::Uncloneable(name) => write!(
                 f,
                 "Component {name} cannot be cloned, and therefor cannot be inserted using merge mode.",

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -3,6 +3,7 @@ use bevy_ecs::component::ComponentId;
 use bevy_ecs::prelude::{Bundle, Entity, EntityRef, Name, Resource, World};
 use bevy_ecs::ptr::OwningPtr;
 use bevy_ecs::relationship::RelationshipHookMode;
+use bevy_utils::prelude::DebugName;
 use std::alloc::alloc;
 use std::any::TypeId;
 use std::error::Error;
@@ -106,11 +107,13 @@ impl BundleInspector {
             .unwrap(); // Already checked that component is registered.
 
         if component_info.drop().is_some() {
-            return Err(MultiWorldCopyError::UnCopyable(type_id));
+            return Err(MultiWorldCopyError::UnCopyable(component_info.name()));
         }
 
         let Some(src) = self.world.get_by_id(self.scratch_entity, src_component_id) else {
-            return Err(MultiWorldCopyError::MissingSrcComponent(type_id));
+            return Err(MultiWorldCopyError::MissingSrcComponent(
+                component_info.name(),
+            ));
         };
 
         unsafe {
@@ -136,12 +139,12 @@ impl BundleInspector {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum MultiWorldCopyError {
     Unregistered(TypeId),
-    UnCopyable(TypeId),
+    UnCopyable(DebugName),
     MissingDstEntity(Entity),
-    MissingSrcComponent(TypeId),
+    MissingSrcComponent(DebugName),
 }
 
 impl std::fmt::Display for MultiWorldCopyError {
@@ -151,17 +154,17 @@ impl std::fmt::Display for MultiWorldCopyError {
                 f,
                 "Component with type ID {type_id:?} has not been registered in the inspector world, and therefor cannot be inserted using merge mode."
             ),
-            MultiWorldCopyError::UnCopyable(type_id) => write!(
+            MultiWorldCopyError::UnCopyable(name) => write!(
                 f,
-                "Component with type ID {type_id:?} cannot be copied, and therefor cannot be inserted using merge mode."
+                "Component {name} cannot be copied, and therefor cannot be inserted using merge mode.",
             ),
             MultiWorldCopyError::MissingDstEntity(entity) => write!(
                 f,
                 "Entity {entity} does not exist in the destination world."
             ),
-            MultiWorldCopyError::MissingSrcComponent(type_id) => write!(
+            MultiWorldCopyError::MissingSrcComponent(name) => write!(
                 f,
-                "Component with type ID {type_id:?} does not exist in inspector world, and therefor cannot be inserted using merge mode."
+                "Component {name} does not exist in inspector world, and therefor cannot be inserted using merge mode.",
             ),
         }
     }

--- a/src/bundle_inspector.rs
+++ b/src/bundle_inspector.rs
@@ -1,6 +1,8 @@
 use crate::EffectMode;
-use bevy_ecs::component::ComponentId;
-use bevy_ecs::prelude::{Bundle, Entity, EntityRef, Name, Resource, World};
+use bevy_ecs::component::{ComponentCloneBehavior, ComponentId};
+use bevy_ecs::prelude::{
+    AppTypeRegistry, Bundle, Entity, EntityRef, Name, ReflectComponent, Resource, World,
+};
 use bevy_ecs::ptr::OwningPtr;
 use bevy_ecs::relationship::RelationshipHookMode;
 use bevy_utils::prelude::DebugName;
@@ -32,6 +34,8 @@ impl BundleInspector {
     ///
     /// Should be [cleared](Self::clear) when finished.
     pub fn stash_bundle<B: Bundle>(&mut self, bundle: B) -> &mut Self {
+        self.clear();
+
         self.world
             .entity_mut(self.scratch_entity)
             .insert_with_relationship_hook_mode(bundle, RelationshipHookMode::Skip);
@@ -97,42 +101,60 @@ impl BundleInspector {
         type_id: TypeId,
         src_component_id: ComponentId,
     ) -> Result<&Self, MultiWorldCopyError> {
-        let Some(existing_component_id) = dst_world.components().get_id(type_id) else {
+        let Some(dst_component_id) = dst_world.components().get_id(type_id) else {
             return Err(MultiWorldCopyError::Unregistered(type_id));
         };
 
-        let component_info = dst_world
-            .components()
-            .get_info(existing_component_id)
-            .unwrap(); // Already checked that component is registered.
+        let component_info = dst_world.components().get_info(dst_component_id).unwrap(); // Already checked that component is registered.
 
-        if component_info.drop().is_some() {
-            return Err(MultiWorldCopyError::UnCopyable(component_info.name()));
+        match component_info.clone_behavior() {
+            ComponentCloneBehavior::Default | ComponentCloneBehavior::Custom(_) => {}
+            ComponentCloneBehavior::Ignore => {
+                return Err(MultiWorldCopyError::Uncloneable(component_info.name()));
+            }
         }
 
         let Some(src) = self.world.get_by_id(self.scratch_entity, src_component_id) else {
             return Err(MultiWorldCopyError::MissingSrcComponent(
                 component_info.name(),
+                self.scratch_entity,
             ));
         };
 
-        unsafe {
-            // SAFETY: Contract is required to be upheld by the world.
-            let dst = alloc(component_info.layout());
+        if component_info.drop().is_none() {
+            unsafe {
+                // SAFETY: Contract is required to be upheld by the world.
+                let dst = alloc(component_info.layout());
 
-            // SAFETY: `dst` is allocated from the component's layout.
-            // Both IDs provided by the caller must match, and `src` and `dst` obtained using the IDs.
-            // `src` and `dst` are from different worlds, so cannot overlap.
-            copy_nonoverlapping(src.as_ptr(), dst, component_info.layout().size());
+                // SAFETY: `dst` is allocated from the component's layout.
+                // Both IDs provided by the caller must match, and `src` and `dst` obtained using the IDs.
+                // `src` and `dst` are from different worlds, so cannot overlap.
+                copy_nonoverlapping(src.as_ptr(), dst, component_info.layout().size());
 
-            let owning = OwningPtr::new(NonNull::new(dst).unwrap());
+                let owning = OwningPtr::new(NonNull::new(dst).unwrap());
 
-            // SAFETY: `existing_component_id` is extracted from `dst_world`.
-            // Both IDs provided by the caller must match, `owning` was obtained using `src_component_id`.
-            dst_world
-                .get_entity_mut(dst_entity)
-                .map_err(|_| MultiWorldCopyError::MissingDstEntity(dst_entity))?
-                .insert_by_id(existing_component_id, owning);
+                // SAFETY: `existing_component_id` is extracted from `dst_world`.
+                // Both IDs provided by the caller must match, `owning` was obtained using `src_component_id`.
+                dst_world
+                    .get_entity_mut(dst_entity)
+                    .map_err(|_| MultiWorldCopyError::MissingDstEntity(dst_entity))?
+                    .insert_by_id(dst_component_id, owning);
+            }
+        } else {
+            let registry = dst_world.resource::<AppTypeRegistry>().clone();
+            let registry = registry.read();
+
+            let reflect_component = registry
+                .get_type_data::<ReflectComponent>(type_id)
+                .ok_or(MultiWorldCopyError::Uncloneable(component_info.name()))?;
+
+            reflect_component.copy(
+                &self.world,
+                dst_world,
+                self.scratch_entity,
+                dst_entity,
+                &registry,
+            );
         }
 
         Ok(self)
@@ -142,9 +164,9 @@ impl BundleInspector {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum MultiWorldCopyError {
     Unregistered(TypeId),
-    UnCopyable(DebugName),
+    Uncloneable(DebugName),
     MissingDstEntity(Entity),
-    MissingSrcComponent(DebugName),
+    MissingSrcComponent(DebugName, Entity),
 }
 
 impl std::fmt::Display for MultiWorldCopyError {
@@ -152,19 +174,19 @@ impl std::fmt::Display for MultiWorldCopyError {
         match self {
             MultiWorldCopyError::Unregistered(type_id) => write!(
                 f,
-                "Component with type ID {type_id:?} has not been registered in the inspector world, and therefor cannot be inserted using merge mode."
+                "Component with {type_id:?} has not been registered in the destination world, and therefor cannot be cloned."
             ),
-            MultiWorldCopyError::UnCopyable(name) => write!(
+            MultiWorldCopyError::Uncloneable(name) => write!(
                 f,
-                "Component {name} cannot be copied, and therefor cannot be inserted using merge mode.",
+                "Component {name} cannot be cloned, and therefor cannot be inserted using merge mode.",
             ),
             MultiWorldCopyError::MissingDstEntity(entity) => write!(
                 f,
                 "Entity {entity} does not exist in the destination world."
             ),
-            MultiWorldCopyError::MissingSrcComponent(name) => write!(
+            MultiWorldCopyError::MissingSrcComponent(name, entity) => write!(
                 f,
-                "Component {name} does not exist in inspector world, and therefor cannot be inserted using merge mode.",
+                "Component {name} does not exist on the scratch entity {entity}, and therefor cannot be cloned.",
             ),
         }
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,5 @@
 use crate::bundle_inspector::BundleInspector;
-use crate::registry::{EffectMergeFn, EffectMergeRegistry};
+use crate::registry::EffectMergeRegistry;
 use crate::{EffectMode, EffectedBy, Effecting};
 use bevy_ecs::prelude::*;
 use bevy_log::{warn, warn_once};
@@ -17,58 +17,44 @@ pub struct AddEffectCommand<B: Bundle> {
 }
 
 impl<B: Bundle> AddEffectCommand<B> {
+    /// Returns the bundle with the relationship component.
     fn bundle_full(self) -> (Effecting, B) {
         (Effecting(self.target), self.bundle)
     }
 
+    /// Merges the [stashed bundle](Self::stash_bundle) with an entity from the given world.
+    /// This is done by calling the [`EffectMergeFn`] for all components in the [registry](EffectMergeRegistry).
+    /// Components not in the registry will be copied to the target entity.
     fn merge(self, world: &mut World, existing_entity: Entity) {
-        if !world.contains_resource::<EffectMergeRegistry>() {
-            warn_once!(
-                "No `EffectComponentMergeRegistry` found. Did you forget to add the `AlchemyPlugin`?"
-            );
-            return;
-        }
+        world
+            .try_resource_scope::<BundleInspector, ()>(|world, inspector| {
+                world.try_resource_scope::<EffectMergeRegistry, ()>(|world, registry| {
+                    for incoming_component_id in inspector.get_ref().archetype().components() {
+                        let type_id = inspector.get_type_id(*incoming_component_id).unwrap();
 
-        world.try_resource_scope::<BundleInspector, ()>(|world, inspector| {
-            world.try_resource_scope::<EffectMergeRegistry, ()>(|world, registry| {
-                let incoming = inspector.get_ref();
-
-                let merge_functions: Vec<EffectMergeFn> = incoming
-                    .archetype()
-                    .components()
-                    .iter()
-                    .filter_map(|incoming_component_id| {
-                        let type_id = inspector.get_type_id(*incoming_component_id)?;
-
-                        if let Some(merge_fn) = registry.merges.get(&type_id) {
-                            return Some(*merge_fn);
+                        if let Some(merge) = registry.merges.get(&type_id) {
+                            merge(&mut world.entity_mut(existing_entity), &inspector.get_ref());
+                            continue;
                         }
 
-                        _ = unsafe {
+                        unsafe {
                             // SAFETY: `incoming_component_id` `type_id` were extracted from the inspector.
-                            inspector
-                                .copy_to_world(
-                                    world,
-                                    existing_entity,
-                                    type_id,
-                                    *incoming_component_id,
-                                )
+                            _ = inspector.copy_to_world(world, existing_entity, type_id, *incoming_component_id)
                                 .inspect_err(|e| {
                                     warn!("{e}");
-                                })
-                        };
-
-                        None
-                    })
-                    .collect();
-
-                let mut existing = world.entity_mut(existing_entity);
-
-                for merge in merge_functions {
-                    merge(&mut existing, &incoming);
-                }
+                                });
+                        }
+                    }
+                })
+                .or_else(|| {
+                    warn_once!("No `EffectMergeRegistry` found. Did you forget to add the `AlchemyPlugin`?");
+                    None
+                });
+            })
+            .or_else(|| {
+                warn_once!("No `BundleInspector` found. Did you forget to add the `AlchemyPlugin`?");
+                None
             });
-        });
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -109,7 +109,11 @@ impl<B: Bundle + Clone> Command for AddEffectCommand<B> {
             EffectMode::Insert => {
                 world.entity_mut(old_entity).insert(self.bundle);
             }
-            EffectMode::Merge => self.merge(world, old_entity),
+            EffectMode::Merge => {
+                // Ensure that all components are registered in the main world for cloning into.
+                world.register_bundle::<B>();
+                self.merge(world, old_entity)
+            }
         }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,10 +1,8 @@
 use crate::bundle_inspector::BundleInspector;
 use crate::registry::{EffectMergeFn, EffectMergeRegistry};
 use crate::{EffectMode, EffectedBy, Effecting};
-use bevy_ecs::entity_disabling::Disabled;
 use bevy_ecs::prelude::*;
-use bevy_log::warn_once;
-use std::any::TypeId;
+use bevy_log::{warn, warn_once};
 
 /// Applies an effect to a target entity.
 /// This *might* spawn a new entity, depending on what effects are already applied to the target.
@@ -38,51 +36,47 @@ impl<B: Bundle> AddEffectCommand<B> {
             return;
         }
 
-        // Copy existing mergeable components to a temporary entity.
-        let new_effect = existing_entity;
-        let old_effect = {
-            let registry = world.resource::<EffectMergeRegistry>();
-            let allow: Vec<TypeId> = registry.merges.keys().copied().collect();
+        world.try_resource_scope::<BundleInspector, ()>(|world, mut inspector| {
+            world.try_resource_scope::<EffectMergeRegistry, ()>(|world, registry| {
+                let incoming = inspector.get_ref();
 
-            let temp = world.spawn(Disabled).id();
-            world
-                .entity_mut(existing_entity)
-                .clone_with_opt_in(temp, |builder| {
-                    builder.without_required_components(|builder| {
-                        builder.allow_by_ids(allow);
-                    });
-                });
+                let merge_functions: Vec<EffectMergeFn> = incoming
+                    .archetype()
+                    .components()
+                    .iter()
+                    .filter_map(|incoming_component_id| {
+                        let type_id = inspector.get_type_id(*incoming_component_id)?;
 
-            temp
-        };
+                        if let Some(merge_fn) = registry.merges.get(&type_id) {
+                            return Some(*merge_fn);
+                        }
 
-        world.entity_mut(new_effect).insert(self.bundle);
+                        _ = unsafe {
+                            inspector
+                                .copy_to_world(
+                                    world,
+                                    existing_entity,
+                                    type_id,
+                                    *incoming_component_id,
+                                )
+                                .inspect_err(|e| {
+                                    warn!("{e}");
+                                })
+                        };
 
-        // Call merge function on those copied components.
-        {
-            let old = world.entity(old_effect);
-            let archetype = old.archetype();
+                        None
+                    })
+                    .collect();
 
-            let registry = world.resource::<EffectMergeRegistry>();
+                let mut existing = world.entity_mut(existing_entity);
 
-            let merge_functions: Vec<EffectMergeFn> = archetype
-                .components()
-                .iter()
-                .filter_map(|component_id| {
-                    world
-                        .components()
-                        .get_info(*component_id)
-                        .and_then(|info| info.type_id())
-                        .and_then(|id| registry.merges.get(&id).copied())
-                })
-                .collect();
+                for merge in merge_functions {
+                    merge(&mut existing, &incoming);
+                }
 
-            for merge in merge_functions {
-                merge(world.entity_mut(new_effect), old_effect);
-            }
-        }
-
-        world.despawn(old_effect);
+                inspector.clear();
+            });
+        });
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -33,8 +33,12 @@ impl<B: Bundle> AddEffectCommand<B> {
                         let type_id = inspector.get_type_id(*incoming_component_id).unwrap();
 
                         if let Some(merge) = registry.merges.get(&type_id) {
-                            merge(&mut world.entity_mut(existing_entity), &inspector.get_ref());
-                            continue;
+                            let entity_mut = world.entity_mut(existing_entity);
+
+                            if entity_mut.contains_type_id(type_id) {
+                                merge(entity_mut, inspector.get_ref());
+                                continue;
+                            }
                         }
 
                         unsafe {
@@ -46,10 +50,10 @@ impl<B: Bundle> AddEffectCommand<B> {
                         }
                     }
                 })
-                .or_else(|| {
-                    warn_once!("No `EffectMergeRegistry` found. Did you forget to add the `AlchemyPlugin`?");
-                    None
-                });
+                    .or_else(|| {
+                        warn_once!("No `EffectMergeRegistry` found. Did you forget to add the `AlchemyPlugin`?");
+                        None
+                    });
             })
             .or_else(|| {
                 warn_once!("No `BundleInspector` found. Did you forget to add the `AlchemyPlugin`?");
@@ -107,8 +111,6 @@ impl<B: Bundle + Clone> Command for AddEffectCommand<B> {
             }
             EffectMode::Merge => self.merge(world, old_entity),
         }
-
-        world.resource_mut::<BundleInspector>().clear();
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -21,13 +21,6 @@ impl<B: Bundle> AddEffectCommand<B> {
         (Effecting(self.target), self.bundle)
     }
 
-    /// Inserts into the existing entity, and then merges the old effect into it using [`EffectMergeRegistry`].
-    /// Only registered components that implement `Clone` will be merged.
-    /// ## Steps
-    /// 1. Copy unregistered components to a new temporary, disabled entity.
-    /// 2. Insert new components into the existing entity.
-    /// 3. Merge the old components (temp entity) with the new ones (existing entity).
-    /// 4. Despawn temp entity.
     fn merge(self, world: &mut World, existing_entity: Entity) {
         if !world.contains_resource::<EffectMergeRegistry>() {
             warn_once!(
@@ -52,6 +45,7 @@ impl<B: Bundle> AddEffectCommand<B> {
                         }
 
                         _ = unsafe {
+                            // SAFETY: `incoming_component_id` `type_id` were extracted from the inspector.
                             inspector
                                 .copy_to_world(
                                     world,

--- a/src/command.rs
+++ b/src/command.rs
@@ -36,7 +36,7 @@ impl<B: Bundle> AddEffectCommand<B> {
             return;
         }
 
-        world.try_resource_scope::<BundleInspector, ()>(|world, mut inspector| {
+        world.try_resource_scope::<BundleInspector, ()>(|world, inspector| {
             world.try_resource_scope::<EffectMergeRegistry, ()>(|world, registry| {
                 let incoming = inspector.get_ref();
 
@@ -73,8 +73,6 @@ impl<B: Bundle> AddEffectCommand<B> {
                 for merge in merge_functions {
                     merge(&mut existing, &incoming);
                 }
-
-                inspector.clear();
             });
         });
     }
@@ -83,7 +81,9 @@ impl<B: Bundle> AddEffectCommand<B> {
 impl<B: Bundle + Clone> Command for AddEffectCommand<B> {
     fn apply(self, world: &mut World) {
         let mut inspector = world.get_resource_or_init::<BundleInspector>();
-        let (name, mode) = inspector.get_effect_meta(self.bundle.clone());
+        let (name, mode) = inspector
+            .stash_bundle(self.bundle.clone())
+            .get_effect_meta();
 
         if mode == EffectMode::Stack {
             world.spawn(self.bundle_full());
@@ -127,6 +127,8 @@ impl<B: Bundle + Clone> Command for AddEffectCommand<B> {
             }
             EffectMode::Merge => self.merge(world, old_entity),
         }
+
+        world.resource_mut::<BundleInspector>().clear();
     }
 }
 

--- a/src/component/stack.rs
+++ b/src/component/stack.rs
@@ -1,7 +1,7 @@
 use crate::EffectMergeRegistry;
 use bevy_app::{App, Plugin};
-use bevy_ecs::prelude::ReflectComponent;
-use bevy_ecs::prelude::{Component, Entity, EntityWorldMut};
+use bevy_ecs::prelude::{Component, EntityWorldMut};
+use bevy_ecs::prelude::{EntityRef, ReflectComponent};
 use bevy_reflect::Reflect;
 use bevy_reflect::prelude::ReflectDefault;
 use std::ops::{Add, AddAssign, Deref, DerefMut};
@@ -82,7 +82,7 @@ impl From<EffectStacks> for u8 {
 }
 
 /// A [merge function](crate::EffectMergeFn) for the [`EffectStacks`] component.
-pub fn merge_effect_stacks(mut new: EntityWorldMut, outgoing: Entity) {
-    let outgoing = *new.world().get::<EffectStacks>(outgoing).unwrap();
-    *new.get_mut::<EffectStacks>().unwrap() += outgoing.0;
+pub fn merge_effect_stacks(existing: &mut EntityWorldMut, incoming: &EntityRef) {
+    let incoming = incoming.get::<EffectStacks>().unwrap();
+    *existing.get_mut::<EffectStacks>().unwrap() += incoming.0;
 }

--- a/src/component/stack.rs
+++ b/src/component/stack.rs
@@ -82,7 +82,7 @@ impl From<EffectStacks> for u8 {
 }
 
 /// A [merge function](crate::EffectMergeFn) for the [`EffectStacks`] component.
-pub fn merge_effect_stacks(existing: &mut EntityWorldMut, incoming: &EntityRef) {
+pub fn merge_effect_stacks(mut existing: EntityWorldMut, incoming: EntityRef) {
     let incoming = incoming.get::<EffectStacks>().unwrap();
     *existing.get_mut::<EffectStacks>().unwrap() += incoming.0;
 }

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -24,8 +24,8 @@ impl Plugin for TimerPlugin {
 
 /// A [merge function](crate::EffectMergeFn) for [`EffectTimer`] components ([`Lifetime`] and [`Delay`]).
 pub fn merge_effect_timer<T: EffectTimer + Component<Mutability = Mutable>>(
-    existing: &mut EntityWorldMut,
-    incoming: &EntityRef,
+    mut existing: EntityWorldMut,
+    incoming: EntityRef,
 ) {
     let incoming = incoming.get::<T>().unwrap();
     existing.get_mut::<T>().unwrap().merge(incoming);

--- a/src/component/timer.rs
+++ b/src/component/timer.rs
@@ -2,11 +2,12 @@ use crate::ReflectComponent;
 use crate::registry::EffectMergeRegistry;
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::component::Mutable;
-use bevy_ecs::prelude::{Commands, Component, Entity, Query, Res};
+use bevy_ecs::prelude::{Commands, Component, Entity, EntityRef, Query, Res};
 use bevy_ecs::schedule::IntoScheduleConfigs;
 use bevy_ecs::world::EntityWorldMut;
 use bevy_reflect::Reflect;
 use bevy_time::{Time, Timer, TimerMode};
+use std::fmt::Debug;
 use std::time::Duration;
 
 pub(crate) struct TimerPlugin;
@@ -22,16 +23,16 @@ impl Plugin for TimerPlugin {
 }
 
 /// A [merge function](crate::EffectMergeFn) for [`EffectTimer`] components ([`Lifetime`] and [`Delay`]).
-pub fn merge_effect_timer<T: EffectTimer + Component<Mutability = Mutable> + Clone>(
-    mut new: EntityWorldMut,
-    outgoing: Entity,
+pub fn merge_effect_timer<T: EffectTimer + Component<Mutability = Mutable>>(
+    existing: &mut EntityWorldMut,
+    incoming: &EntityRef,
 ) {
-    let outgoing = new.world().get::<T>(outgoing).unwrap().clone();
-    new.get_mut::<T>().unwrap().merge(&outgoing);
+    let incoming = incoming.get::<T>().unwrap();
+    existing.get_mut::<T>().unwrap().merge(incoming);
 }
 
 /// A [timer](Timer) which is used for status effects and includes a [`TimerMergeMode`].
-pub trait EffectTimer: Sized {
+pub trait EffectTimer: Clone {
     /// Creates a new timer from a duration.
     fn new(duration: Duration) -> Self;
 
@@ -59,24 +60,27 @@ pub trait EffectTimer: Sized {
     /// Behaviour depends on the current [`TimerMergeMode`].
     fn merge(&mut self, incoming: &Self) {
         match self.get_mode() {
-            TimerMergeMode::Replace => {}
-            TimerMergeMode::Keep => *self.get_timer_mut() = incoming.get_timer().clone(),
+            TimerMergeMode::Replace => self.clone_from(incoming),
+            TimerMergeMode::Keep => {}
             TimerMergeMode::Fraction => {
-                let fraction = incoming.get_timer().fraction();
-                let duration = self.get_timer().duration().as_secs_f32();
+                let fraction = self.get_timer().fraction();
+                let duration = incoming.get_timer().duration().as_secs_f32();
+
+                self.clone_from(incoming);
                 self.get_timer_mut()
                     .set_elapsed(Duration::from_secs_f32(fraction * duration));
             }
             TimerMergeMode::Max => {
-                let old = incoming.get_timer().remaining_secs();
-                let new = self.get_timer().remaining_secs();
+                let old = self.get_timer().remaining_secs();
+                let new = incoming.get_timer().remaining_secs();
 
-                if old > new {
-                    *self.get_timer_mut() = incoming.get_timer().clone();
+                if new > old {
+                    self.clone_from(incoming);
                 }
             }
             TimerMergeMode::Sum => {
-                let duration = incoming.get_timer().duration() + self.get_timer().duration();
+                let duration = self.get_timer().duration() + incoming.get_timer().duration();
+                self.clone_from(incoming);
                 self.get_timer_mut().set_duration(duration);
             }
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 ///     new.get_mut::<MyEffect>().unwrap().0 += outgoing.0;
 /// }
 /// ```
-pub type EffectMergeFn = fn(new: EntityWorldMut, outgoing: Entity);
+pub type EffectMergeFn = fn(existing: &mut EntityWorldMut, incoming: &EntityRef);
 
 /// Stores the effect merge logic for each registered component.
 /// New components can be registered by providing a [`EffectMergeFn`] to the [`register`](EffectMergeRegistry::register) method.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 /// #[derive(Component, Clone)]
 /// struct MyEffect(f32);
 ///
-/// fn merge_my_effect(existing: &mut EntityWorldMut, incoming: &EntityRef) {
+/// fn merge_my_effect(mut existing: EntityWorldMut, incoming: EntityRef) {
 ///     let incoming = incoming.get::<MyEffect>().unwrap();
 ///     existing.get_mut::<MyEffect>().unwrap().0 += incoming.0;
 /// }
 /// ```
-pub type EffectMergeFn = fn(existing: &mut EntityWorldMut, incoming: &EntityRef);
+pub type EffectMergeFn = fn(existing: EntityWorldMut, incoming: EntityRef);
 
 /// Stores the effect merge logic for each registered component.
 /// New components can be registered by providing a [`EffectMergeFn`] to the [`register`](EffectMergeRegistry::register) method.
@@ -37,7 +37,7 @@ pub type EffectMergeFn = fn(existing: &mut EntityWorldMut, incoming: &EntityRef)
 ///         .register::<MyEffect>(merge_my_effect);
 /// }
 ///
-/// fn merge_my_effect(existing: &mut EntityWorldMut, incoming: &EntityRef) {
+/// fn merge_my_effect(mut existing: EntityWorldMut, incoming: EntityRef) {
 ///     let incoming = incoming.get::<MyEffect>().unwrap();
 ///     existing.get_mut::<MyEffect>().unwrap().0 += incoming.0;
 /// }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -48,7 +48,7 @@ pub struct EffectMergeRegistry {
 }
 
 impl EffectMergeRegistry {
-    /// Registers a [`EffectMergeFn`] to be run whenever two `T` status effects are merged.
+    /// Registers a [`EffectMergeFn`] to be run whenever two `T` status effect components are merged.
     pub fn register<T: Component + Clone>(&mut self, f: EffectMergeFn) -> &mut Self {
         self.merges.insert(TypeId::of::<T>(), f);
         self

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,9 +12,9 @@ use std::collections::HashMap;
 /// #[derive(Component, Clone)]
 /// struct MyEffect(f32);
 ///
-/// fn merge_my_effect(mut new: EntityWorldMut, outgoing: Entity) {
-///     let outgoing = new.world().get::<MyEffect>(outgoing).unwrap().clone();
-///     new.get_mut::<MyEffect>().unwrap().0 += outgoing.0;
+/// fn merge_my_effect(existing: &mut EntityWorldMut, incoming: &EntityRef) {
+///     let incoming = incoming.get::<MyEffect>().unwrap();
+///     existing.get_mut::<MyEffect>().unwrap().0 += incoming.0;
 /// }
 /// ```
 pub type EffectMergeFn = fn(existing: &mut EntityWorldMut, incoming: &EntityRef);
@@ -37,9 +37,9 @@ pub type EffectMergeFn = fn(existing: &mut EntityWorldMut, incoming: &EntityRef)
 ///         .register::<MyEffect>(merge_my_effect);
 /// }
 ///
-/// fn merge_my_effect(mut new: EntityWorldMut, outgoing: Entity) {
-///     let outgoing = new.world().get::<MyEffect>(outgoing).unwrap().clone();
-///     new.get_mut::<MyEffect>().unwrap().0 += outgoing.0;
+/// fn merge_my_effect(existing: &mut EntityWorldMut, incoming: &EntityRef) {
+///     let incoming = incoming.get::<MyEffect>().unwrap();
+///     existing.get_mut::<MyEffect>().unwrap().0 += incoming.0;
 /// }
 /// ```
 #[derive(Resource, Default)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 /// A function used to merge effects with [`EffectMode::Merge`](crate::EffectMode::Merge),
 /// which must be registered in the [registry](EffectMergeRegistry).
 ///
+/// The component the function is registered for is guaranteed to exist on both provided entities.
+/// Note that the incoming entity exists in a **separate world**.
+///
 /// # Example
 /// ```rust
 /// # use bevy_ecs::prelude::*;
@@ -13,8 +16,9 @@ use std::collections::HashMap;
 /// struct MyEffect(f32);
 ///
 /// fn merge_my_effect(mut existing: EntityWorldMut, incoming: EntityRef) {
+///     let mut existing = existing.get_mut::<MyEffect>().unwrap();
 ///     let incoming = incoming.get::<MyEffect>().unwrap();
-///     existing.get_mut::<MyEffect>().unwrap().0 += incoming.0;
+///     existing.0 += incoming.0;
 /// }
 /// ```
 pub type EffectMergeFn = fn(existing: EntityWorldMut, incoming: EntityRef);
@@ -38,8 +42,9 @@ pub type EffectMergeFn = fn(existing: EntityWorldMut, incoming: EntityRef);
 /// }
 ///
 /// fn merge_my_effect(mut existing: EntityWorldMut, incoming: EntityRef) {
+///     let mut existing = existing.get_mut::<MyEffect>().unwrap();
 ///     let incoming = incoming.get::<MyEffect>().unwrap();
-///     existing.get_mut::<MyEffect>().unwrap().0 += incoming.0;
+///     existing.0 += incoming.0;
 /// }
 /// ```
 #[derive(Resource, Default)]

--- a/tests/effect_mode.rs
+++ b/tests/effect_mode.rs
@@ -13,6 +13,7 @@ fn init_world() -> World {
 
     let mut registry = EffectMergeRegistry::default();
     registry
+        .register::<EffectStacks>(merge_effect_stacks)
         .register::<Lifetime>(merge_effect_timer::<Lifetime>)
         .register::<Delay>(merge_effect_timer::<Delay>);
 
@@ -101,6 +102,42 @@ fn mixed() {
     assert!(effects.contains(&1));
     assert!(!effects.contains(&2));
     assert!(effects.contains(&3));
+}
+
+#[test]
+fn effect_stacks_merge() {
+    let mut world = init_world();
+
+    let target = world.spawn_empty().id();
+    world.commands().entity(target).with_effect((
+        EffectMode::Merge,
+        MyEffect(0),
+        EffectStacks::default(),
+    ));
+    world.commands().entity(target).with_effect((
+        EffectMode::Merge,
+        MyEffect(1),
+        EffectStacks::default(),
+        Delay::default(),
+    ));
+
+    world.flush();
+
+    // Component with merge function:
+    assert_eq!(
+        world.query::<&EffectStacks>().single(&world).unwrap(),
+        &EffectStacks(2),
+    );
+    // Component without, and already present on effect.
+    assert_eq!(
+        world.query::<&MyEffect>().single(&world).unwrap(),
+        &MyEffect(1)
+    );
+    // Component without, and not present on effect.
+    assert_eq!(
+        world.query::<&Delay>().single(&world).unwrap(),
+        &Delay::default()
+    )
 }
 
 #[test]

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -5,20 +5,19 @@ use std::time::Duration;
 
 #[test]
 fn merge_replace() {
-    let first = Lifetime::from_seconds(1.0).with_mode(TimerMergeMode::Replace);
+    let mut first = Lifetime::from_seconds(1.0).with_mode(TimerMergeMode::Replace);
     let second = Lifetime::from_seconds(2.0).with_mode(TimerMergeMode::Replace);
-    let mut result = second.clone();
-    result.merge(&first);
+    first.merge(&second);
 
-    assert_eq!(result, second);
+    assert_eq!(first, second);
 }
 
 #[test]
 fn merge_keep() {
     let first = Lifetime::from_seconds(1.0).with_mode(TimerMergeMode::Keep);
     let second = Lifetime::from_seconds(2.0).with_mode(TimerMergeMode::Keep);
-    let mut result = second.clone();
-    result.merge(&first);
+    let mut result = first.clone();
+    result.merge(&second);
 
     assert_eq!(result, first);
 }
@@ -27,8 +26,8 @@ fn merge_keep() {
 fn merge_fraction() {
     let first = Lifetime::from_seconds(1.0).with_mode(TimerMergeMode::Fraction);
     let second = Lifetime::from_seconds(2.0).with_mode(TimerMergeMode::Fraction);
-    let mut result = second.clone();
-    result.merge(&first);
+    let mut result = first.clone();
+    result.merge(&second);
 
     assert_eq!(result, second);
 }


### PR DESCRIPTION
The effect merging system has be overhauled to use the the `BundleInspector` added in V0.4. This way, temporary entities are fully isolated from the main world.

# Migration Guide
This change also makes merge functions themselves more ergonomic, providing an `EntityRef` instead of an entity ID. Note that **this swaps the direction of the merge**! The results of merge logic should now be applied to the ***existing** component*.

Before:
```rust
fn merge_my_effect(mut new: EntityWorldMut, outgoing: Entity) {
    let outgoing = new.world().get::<MyEffect>(outgoing).unwrap().clone();
    let mut new = new.get_mut::<MyEffect>().unwrap();
    new.0 += outgoing.0;
}
```
After:
```rust
fn merge_my_effect(mut existing: EntityWorldMut, incoming: EntityRef) {
    let mut existing = existing.get_mut::<MyEffect>().unwrap();
    let incoming = incoming.get::<MyEffect>().unwrap();
    existing.0 += incoming.0;
}
```